### PR TITLE
Implement Packet System for BME680

### DIFF
--- a/ascendfsw/include/BME680Sensor.h
+++ b/ascendfsw/include/BME680Sensor.h
@@ -42,6 +42,7 @@ class BME680Sensor : public Sensor {
 
   bool verify() override;
   String readData() override;
+  void readDataPacket(uint8_t*& packet) override;
 };
 
 #endif

--- a/ascendfsw/include/BME680Sensor.h
+++ b/ascendfsw/include/BME680Sensor.h
@@ -42,8 +42,8 @@ class BME680Sensor : public Sensor {
 
   bool verify() override;
   String readData() override;
-  void readDataPacket(uint8_t*& packet) override;
-  String decodeToCSV(uint8_t* packet) override;
+  void readDataPacket(uint8_t*& packet);
+  String decodeToCSV(uint8_t* packet);
 };
 
 #endif

--- a/ascendfsw/include/BME680Sensor.h
+++ b/ascendfsw/include/BME680Sensor.h
@@ -43,6 +43,7 @@ class BME680Sensor : public Sensor {
   bool verify() override;
   String readData() override;
   void readDataPacket(uint8_t*& packet) override;
+  String decodeToCSV(uint8_t* packet) override;
 };
 
 #endif

--- a/ascendfsw/src/BME680Sensor.cpp
+++ b/ascendfsw/src/BME680Sensor.cpp
@@ -77,3 +77,30 @@ String BME680Sensor::readData() {
          String(bme.humidity) + "," + String(bme.gas_resistance) + "," +
          String(bme.readAltitude(SEALEVELPRESSURE_HPA)) + ",";
 }
+
+/**
+ * @brief Reads sensor data and appends it to the packet byte array.
+ *
+ * Reads data from the BME680 sensor and appends it to the passed uint8_t array
+ * pointer, incrementing it while doing so. The data includes temperature,
+ * pressure, humidity, gas resistance, and an approximate altitude based on
+ * sea-level pressure.
+ *
+ * @param packet - Pointer to the packet byte array.
+ */
+void BME680Sensor::readDataPacket(uint8_t*& packet) {
+  if (!bme.performReading()) {
+    return;
+  }
+
+  float data[5] = {bme.temperature, bme.pressure / 100.0, bme.humidity,
+                   bme.gas_resistance, bme.readAltitude(SEALEVELPRESSURE_HPA)};
+
+  
+  for (int i = 0; i < 5; i++) {
+    memcpy(packet, &data[i], sizeof(float));
+    packet += sizeof(float); 
+  }
+}
+
+

--- a/ascendfsw/src/BME680Sensor.cpp
+++ b/ascendfsw/src/BME680Sensor.cpp
@@ -96,11 +96,30 @@ void BME680Sensor::readDataPacket(uint8_t*& packet) {
   float data[5] = {bme.temperature, bme.pressure / 100.0, bme.humidity,
                    bme.gas_resistance, bme.readAltitude(SEALEVELPRESSURE_HPA)};
 
-  
+
   for (int i = 0; i < 5; i++) {
     memcpy(packet, &data[i], sizeof(float));
     packet += sizeof(float); 
   }
 }
 
+/**
+ * @brief Decodes the packet data and returns it in CSV format.
+ *
+ * Decodes the packet data from the BME680 sensor and returns it in CSV format.
+ * The data includes temperature, pressure, humidity, gas resistance, and an
+ * approximate altitude based on sea-level pressure.
+ *
+ * @param packet - Packet to decode.
+ * @return String - A string containing the sensor readings
+ */
+String BME680Sensor::decodeToCSV(uint8_t* packet) {
+  float data[5];
+  for (int i = 0; i < 5; i++) {
+    memcpy(&data[i], packet, sizeof(float));
+    packet += sizeof(float);
+  }
 
+  return String(data[0]) + "," + String(data[1]) + "," + String(data[2]) + "," +
+         String(data[3]) + "," + String(data[4]) + ",";
+}


### PR DESCRIPTION
**Pull Request Description**

This PR adds packet-based data handling to the `BME680Sensor` class. In addition to the original CSV-based `readData()` method, two new functions handle binary packets:

- **`readDataPacket(uint8_t*& packet)`**: Reads sensor data (temperature, pressure, humidity, gas resistance, altitude) into a float array and appends it to the provided buffer.  
- **`decodeToCSV(uint8_t* packet)`**: Decodes the float array back into a CSV string.

This approach reduces string overhead, allowing more efficient data transfer and easier parsing in multi-core or buffered systems, while maintaining backward compatibility with existing CSV output.