### PR TITLE
MTK3339Sensor Expansion

### DIFF
--- a/ascendfsw/include/MTK3339Sensor.h
+++ b/ascendfsw/include/MTK3339Sensor.h
@@ -24,6 +24,8 @@ class MTK3339Sensor : public Sensor {
 
   bool verify() override;
   String readData() override;
+  void readDataPacket(uint8_t*& packet);
+  String decodeToCSV(uint8_t*& packet);
 };
 
 #endif

--- a/ascendfsw/src/MTK3339Sensor.cpp
+++ b/ascendfsw/src/MTK3339Sensor.cpp
@@ -84,3 +84,123 @@ String MTK3339Sensor::readData() {
   }
   return "-,-,-,-,-,-,-,";
 }
+
+
+/**
+ * @brief Appends the MTK3339 sensor data to the packet buffer as raw bytes.
+ *
+ * The following data are appended in order:
+ *   - Date: day (uint8_t), month (uint8_t), year (uint16_t)
+ *   - Latitude (float)
+ *   - Longitude (float)
+ *   - Speed (float)
+ *   - Angle (float)
+ *   - Altitude (float)
+ *   - Satellites (uint8_t)
+ *
+ * If no valid fix is available, default value (0) is appended for all fields.
+ *
+ * @param packet Pointer to the packet byte array. This pointer is incremented as each value is copied.
+ */
+void MTK3339Sensor::readDataPacket(uint8_t*& packet) {
+  if (GPS.fix) {
+    // Pack date values
+    uint8_t day = GPS.day;
+    uint8_t month = GPS.month;
+    uint16_t year = GPS.year;
+    memcpy(packet, &day, sizeof(day));
+    packet += sizeof(day);
+    memcpy(packet, &month, sizeof(month));
+    packet += sizeof(month);
+    memcpy(packet, &year, sizeof(year));
+    packet += sizeof(year);
+    // Pack latitude, longitude, speed, angle, and altitude as floats
+    float lat = GPS.latitude;
+    float lon = GPS.longitude;
+    float speed = GPS.speed;
+    float angle = GPS.angle;
+    float alt = GPS.altitude;
+    memcpy(packet, &lat, sizeof(lat));
+    packet += sizeof(lat);
+    memcpy(packet, &lon, sizeof(lon));
+    packet += sizeof(lon);
+    memcpy(packet, &speed, sizeof(speed));
+    packet += sizeof(speed);
+    memcpy(packet, &angle, sizeof(angle));
+    packet += sizeof(angle);
+    memcpy(packet, &alt, sizeof(alt));
+    packet += sizeof(alt);
+    // Pack number of satellites as uint8_t
+    uint8_t sats = GPS.satellites;
+    memcpy(packet, &sats, sizeof(sats));
+    packet += sizeof(sats);
+  } else {
+    // If there's no fix, append default zero values
+    uint8_t day = 0;
+    uint8_t month = 0;
+    uint16_t year = 0;
+    memcpy(packet, &day, sizeof(day));
+    packet += sizeof(day);
+    memcpy(packet, &month, sizeof(month));
+    packet += sizeof(month);
+    memcpy(packet, &year, sizeof(year));
+    packet += sizeof(year);
+    float zero = 0.0;
+    memcpy(packet, &zero, sizeof(zero));  // Latitude
+    packet += sizeof(zero);
+    memcpy(packet, &zero, sizeof(zero));  // Longitude
+    packet += sizeof(zero);
+    memcpy(packet, &zero, sizeof(zero));  // Speed
+    packet += sizeof(zero);
+    memcpy(packet, &zero, sizeof(zero));  // Angle
+    packet += sizeof(zero);
+    memcpy(packet, &zero, sizeof(zero));  // Altitude
+    packet += sizeof(zero);
+    uint8_t sats = 0;
+    memcpy(packet, &sats, sizeof(sats));
+    packet += sizeof(sats);
+  }
+}
+
+/**
+ * @brief Decodes the MTK3339 sensor data from the packet buffer into a CSV string.
+ *
+ * The data are read in the same order they were written and  reconstructed as a string "day/month/year" and the remaining fields are appended as CSV values.
+ *
+ * @param packet Pointer to the packet byte array and this packet pointer is incremented.
+ * @return String The decoded sensor data in CSV format.
+ */
+String MTK3339Sensor::decodeToCSV(uint8_t*& packet) {
+  // Decode date components
+  uint8_t day = *packet;
+  packet += sizeof(uint8_t);
+  uint8_t month = *packet;
+  packet += sizeof(uint8_t);
+  uint16_t year = *((uint16_t*)packet);
+  packet += sizeof(uint16_t);
+
+  // Decode values: latitude, longitude, speed, angle, altitude. And then decode number of satellites.
+  float lat = *((float*)packet);
+  packet += sizeof(float);
+  float lon = *((float*)packet);
+  packet += sizeof(float);
+  float speed = *((float*)packet);
+  packet += sizeof(float);
+  float angle = *((float*)packet);
+  packet += sizeof(float);
+  float alt = *((float*)packet);
+  packet += sizeof(float);
+  uint8_t sats = *packet;
+  packet += sizeof(uint8_t);
+
+  // Construct the CSV string
+  String dateStr = String(day) + "/ " + String(month) + "/ " + String(year);
+  String csv = dateStr + "," +
+               String(lat) + "," +
+               String(lon) + "," +
+               String(speed) + "," +
+               String(angle) + "," +
+               String(alt) + "," +
+               String(sats) + ",";
+  return csv;
+}


### PR DESCRIPTION
readDataPacket(uint8_t*& packet): Appends sensor data (including date, latitude, longitude, speed, angle, altitude, and satellites) as raw bytes to the packet buffer using memcpy, and increments the pointer appropriately.
decodeToCSV(uint8_t*& packet): Decodes the raw byte data from the packet buffer back into a CSV-formatted string.
